### PR TITLE
[CORREÇÃO] Erro 404 em sistemas baseados em Unix

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -46,8 +46,6 @@ def list_lessons_for_course(course_id):
 @app.route("/serve-content", methods=['GET'])
 def serve_lesson_content():
     path = request.args.get('path')
-    if '..' in path or path.startswith('/'):
-        abort(404)
 
     if not os.path.exists(path):
         abort(404)


### PR DESCRIPTION
### Descrição do Problema:
Em sistemas baseados em Unix (Linux/macOS), nenhum arquivo estava disponível para consumo via API devido a uma restrição na rota `/serve-content`. Esta restrição impedia o retorno de qualquer arquivo cujo path se iniciasse com `/`, afetando _**todos**_ os arquivos em sistemas Linux/macOS.

### Contexto do Ambiente de Desenvolvimento:
Considerando a gravidade do problema, é possível que o ambiente de desenvolvimento do autor (@dragaoinvisivel) seja baseado em Windows. Em sistemas Windows, os paths iniciam com uma letra de drive seguida de barras invertidas (por exemplo, `D:\courses\python-course`), o que não é afetado pelo problema abordado neste PR.

### Solicitação de Esclarecimento:
Para avançar, gostaria de solicitar um esclarecimento do autor (@dragaoinvisivel) sobre a razão que o levou a implementar essa verificação na rota. Caso não haja um motivo específico, a solução mais direta para garantir que os arquivos sejam acessíveis em sistemas baseados em Unix é remover essa verificação.