### PR TITLE
[CORREÇÃO] Conflito na porta 5000 em sistemas macOS

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,4 +37,4 @@ with app.app_context():
     db.create_all()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, port=5050)


### PR DESCRIPTION
### Descrição do Problema:
Recentemente descobrimos que o recurso AirPlay Receiver, presente nos sistemas macOS, utiliza a porta 5000 por padrão e não oferece a possibilidade de alteração dessa configuração através das configurações do sistema. Este é um problema amplamente documentado, como pode ser visto nesta [postagem do StackOverflow](https://stackoverflow.com/questions/72369320/why-always-something-is-running-at-port-5000-on-my-mac) e nesta [discussão no fórum oficial da Apple](https://forums.developer.apple.com/forums/thread/682332). Além disso, há relatos de mais de uma década atrás indicando que a porta 5000 já foi utilizada por outros serviços do sistema, conforme discutido nesta outra [discussão no fórum oficial da Apple](https://discussions.apple.com/thread/635229).
### Impacto:
Se o usuário tiver o AirPlay Receiver ativado, isso o impossibilita de iniciar o projeto. O recurso é configurado como opt-out (ativado por padrão) e é fundamental para os usuários do ecossistema da Apple, portanto desativá-lo seria inconveniente.
### Solução Proposta:
Para resolver esse problema, ajustamos a porta do projeto para uma não convencional, evitando assim conflitos com o AirPlay Receiver configurado na porta 5000 por padrão nos sistemas macOS. É uma prática recomendada evitar o uso de portas amplamente utilizadas em projetos de desenvolvimento (como 3000, 5000, 8000, etc.), pois isso poderia gerar conflitos se o usuário estiver executando outros projetos na mesma máquina. No caso deste projeto, a porta foi modificada para 5050, mas você pode alterá-la conforme necessário.